### PR TITLE
Jake DeathLink

### DIFF
--- a/worlds/grinch/Client.py
+++ b/worlds/grinch/Client.py
@@ -61,6 +61,10 @@ TIMER_ADDR: int = 0x0100B3
 # Address related to Mount Crumpit Elevator's position
 MC_ELEVATOR_ADDR: int = 0x01010D
 
+# Offsets from region table used to handle deathlink related things
+HEALTH_REGION_OFFSET: int = 0x3C
+DEALTHLINK_REGION_OFFSET: int = 0x27
+
 class GrinchClient(BizHawkClient):
     game = "The Grinch"
     system = "PSX"
@@ -72,8 +76,10 @@ class GrinchClient(BizHawkClient):
     previous_egg_count: int = 0
     send_ring_link: bool = False
     unique_client_id: int = 0
-    ring_link_enabled = False
-    is_grinch_dead = bool = False
+    ring_link_enabled: bool = False
+    death_link_enabled: bool = False
+    is_grinch_dead: bool = False
+    curr_region: str | None = None
     #yes
 
     def __init__(self):
@@ -143,7 +149,7 @@ class GrinchClient(BizHawkClient):
                 if not self.loc_unlimited_eggs:
 
                     self.ring_link_enabled = bool(ctx.slot_data["ring_link"])
-                    death_link_enabled = bool(ctx.slot_data["death_link"])
+                    self.death_link_enabled = bool(ctx.slot_data["death_link"])
 
                     tags = copy.deepcopy(ctx.tags)
 
@@ -153,7 +159,7 @@ class GrinchClient(BizHawkClient):
                     else:
                         ctx.tags -= {"RingLink"}
 
-                    if death_link_enabled:
+                    if self.death_link_enabled:
                         ctx.tags.add("DeathLink")
 
                     else:
@@ -177,9 +183,9 @@ class GrinchClient(BizHawkClient):
 
                 tags = args.get("tags", [])
                 # we can skip checking "DeathLink" in ctx.tags, as otherwise we wouldn't have been send this
-                if ("DeathLink" in tags and ctx.last_death_link != args["data"]["time"] and
-                    not args["data"]["source"] == ctx.player_names[ctx.slot]):
-                    self.on_deathlink(args["data"], ctx)
+                if ("DeathLink" in tags and args["data"]["source"] != ctx.player_names[ctx.slot] and
+                    not self.is_grinch_dead):
+                    Utils.async_start(self.kill_grinch(ctx), "Grinch - Received DeathLink")
 
                 if (
                     "RingLink" in ctx.tags
@@ -215,7 +221,9 @@ class GrinchClient(BizHawkClient):
             await self.goal_checker(ctx)
             await self.option_handler(ctx)
             await self.constant_address_update(ctx)
-            await self.check_grinch_alive(ctx)
+
+            if self.death_link_enabled:
+                await self.check_grinch_alive(ctx)
 
         except bizhawk.RequestFailedError as ex:
             # The connector didn't respond. Exit handler and return to main loop to reconnect
@@ -565,7 +573,15 @@ class GrinchClient(BizHawkClient):
             logger.info("You can now start sending locations from the Grinch!")
             self.ingame_log = True
 
+        self.curr_region = await self.get_current_region()
         return True
+
+    async def get_current_region(self) -> str | None:
+        for grinch_region, grinch_data in ALL_REGIONS_INFO.items():
+            # We only care about a region/map that is the same as the grinch
+            if self.last_map_location == grinch_data.map_id:
+                return grinch_region
+        return None
 
     async def option_handler(self, ctx: "BizHawkClientContext"):
         if self.loc_unlimited_eggs:
@@ -712,65 +728,55 @@ class GrinchClient(BizHawkClient):
             continue
 
     async def check_grinch_alive(self, ctx: "BizHawkClientContext"):
-        ingame_map_id = await self.get_current_map_id(ctx)
-        for grinch_data in ALL_REGIONS_INFO.values():
-            # We only care about a region/map that is the same as the grinch
-            if not ingame_map_id == grinch_data.map_id:
-                continue
-
-            # IF the region does not allow deathlink
-            if not grinch_data.allow_deathlink:
-                continue
-
-            # Get the current amount of Heart of Stones (HOS)
-            hos_count = get_item_count_by_id(ctx, 42570)
-            hp_amount = math.ceil(42 - (10.5 * hos_count))
-
-            curr_health: int = int.from_bytes(
-                (await bizhawk.read(ctx.bizhawk_ctx, [(grinch_data.health_addr, 1, "MainRAM")]))[0],
-                "little")
-
-            if curr_health <= hp_amount:
-                await self.kill_grinch(ctx)
-
-    async def kill_grinch(self, ctx: "BizHawkClientContext"):
-        if self.is_grinch_dead or not self.ingame_checker(ctx):
+        reg_name = await self.get_current_region()
+        if not reg_name:
+            return
+        elif self.is_grinch_dead:
             return
 
-        ingame_map_id = await self.get_current_map_id(ctx)
-        for grinch_data in ALL_REGIONS_INFO.values():
-            # We only care about a region/map that is the same as the grinch
-            if not ingame_map_id == grinch_data.map_id:
-                continue
+        curr_region_data = ALL_REGIONS_INFO[reg_name]
+        if not curr_region_data.allow_deathlink:
+            return
 
-            # IF the region does not allow deathlink
-            if not grinch_data.allow_deathlink:
-                continue
+        # Get the current amount of Heart of Stones (HOS)
+        hos_count = get_item_count_by_id(ctx, 42570)
+        hp_amount = math.ceil(42 - (10.5 * hos_count))
 
-            # Get the current amount of Heart of Stones (HOS)
-            hos_count = get_item_count_by_id(ctx, 42570)
-            hp_amount = math.ceil(42 - (10.5 * hos_count))
-            death_link_trigger: int = 0x40
+        curr_health: int = int.from_bytes((await bizhawk.read(ctx.bizhawk_ctx,
+            [(curr_region_data.map_table_addr + HEALTH_REGION_OFFSET, 1, "MainRAM")]))[0], "little")
 
-            # Update the Health Address to X amount and DeathLink Trigger to 0
-            await bizhawk.write(
-                ctx.bizhawk_ctx,
-                [(grinch_data.health_addr, hp_amount.to_bytes(1, "little"), "MainRAM"),
-                 (grinch_data.death_trigger_addr, death_link_trigger.to_bytes(1, "little"), "MainRAM"),],
-            )
+        if curr_health <= hp_amount:
+            await ctx.send_death("Could not fight off the Christmas cheer...")
+            await self.kill_grinch(ctx)
 
-            self.is_grinch_dead = True
 
-    def on_deathlink(self, data: dict, ctx: "BizHawkClientContext"):
-        """Gets dispatched when a new DeathLink is triggered by another linked player."""
-        ctx.last_death_link = max(data["time"], ctx.last_death_link)
-        text = data.get("cause", "")
-        if text:
-            logger.info(f"DeathLink: {text}")
-        else:
-            logger.info(f"DeathLink: Received from {data['source']}")
+    async def kill_grinch(self, ctx: "BizHawkClientContext"):
+        reg_name = await self.get_current_region()
+        if not (await self.ingame_checker(ctx) and reg_name):
+            return
 
-        self.kill_grinch(ctx)
+        # Update the Health Address to X amount and DeathLink Trigger to 0
+        self.is_grinch_dead = True
+        curr_region_data = ALL_REGIONS_INFO[reg_name]
+        await bizhawk.write(
+            ctx.bizhawk_ctx,
+            [(curr_region_data.map_table_addr + HEALTH_REGION_OFFSET, int(0).to_bytes(1, "little"), "MainRAM"),
+             (curr_region_data.map_table_addr + DEALTHLINK_REGION_OFFSET, int(0x40).to_bytes(1, "little"), "MainRAM")],
+        )
+        await self.wait_for_grinch_alive(ctx, curr_region_data.map_table_addr + HEALTH_REGION_OFFSET)
+
+
+    async def wait_for_grinch_alive(self, ctx: "BizHawkClientContext", health_address: int):
+        curr_hp: int = int.from_bytes((await bizhawk.read(ctx.bizhawk_ctx,
+            [(health_address, 1, "MainRAM")]))[0], "little")
+        expected_hp: int = copy.deepcopy(curr_hp)
+        time_to_wait = time.time() + 30
+
+        while curr_hp <= expected_hp and not (time.time() >= time_to_wait):
+            await asyncio.sleep(3.0)
+            curr_hp = int.from_bytes((await bizhawk.read(ctx.bizhawk_ctx,
+            [(health_address, 1, "MainRAM")]))[0], "little")
+        self.is_grinch_dead = False
 
 def _cmd_ringlink(self):
     """Toggle ringling from client. Overrides default setting."""

--- a/worlds/grinch/Regions.py
+++ b/worlds/grinch/Regions.py
@@ -45,8 +45,6 @@ class GrinchRegionInfo(NamedTuple):
     map_id: int
     parent_region: str
     allow_deathlink: bool = False
-    health_addr: Optional[int] = None
-    death_trigger_addr: Optional[int] = None
     map_table_addr: Optional[int] = None
     region_access: Optional[list[list[str]]] = None
     advanced_region_access: Optional[list[list[str]]] = None
@@ -59,33 +57,33 @@ class GrinchRegion(Region):
         self.region_data = region_data
 
 ALL_REGIONS_INFO: dict[str, GrinchRegionInfo] = {
-    "Mount Crumpit": GrinchRegionInfo(0x05, "", False, 0x800FAAF0, 0x800FAADB, 0x800FAAB4),
+    "Mount Crumpit": GrinchRegionInfo(0x05, "", False, 0x0FAAB4),
 
-    "Whoville": GrinchRegionInfo(0x07, "Mount Crumpit", True, 0x800E8FDC, 0x800E8FC7, 0x800E8FA0,
+    "Whoville": GrinchRegionInfo(0x07, "Mount Crumpit", True, 0x0E8FA0,
         region_access=[
             [grinch_items.keys.WHOVILLE],
             ["1:" + grinch_items.keys.PROGRESSIVE_VACUUM_TUBE],
         ],),
 
-    "Who Forest": GrinchRegionInfo(0x0B, "Mount Crumpit", True, 0x800E1C90, 0x800E1C7B, 0x800E1C54,
+    "Who Forest": GrinchRegionInfo(0x0B, "Mount Crumpit", True, 0x0E1C54,
         region_access=[
             [grinch_items.keys.WHO_FOREST],
             ["2:" + grinch_items.keys.PROGRESSIVE_VACUUM_TUBE],
         ],),
 
-    "Who Dump": GrinchRegionInfo(0x0E, "Mount Crumpit", True, 0x800DFF60, 0x800DFF4B, 0x800DFF24,
+    "Who Dump": GrinchRegionInfo(0x0E, "Mount Crumpit", True, 0x0DFF24,
         region_access=[
             [grinch_items.keys.WHO_DUMP],
             ["3:" + grinch_items.keys.PROGRESSIVE_VACUUM_TUBE],
         ],),
 
-    "Who Lake": GrinchRegionInfo(0x12, "Mount Crumpit", True, 0x800DD1A8, 0x800DD193, 0x800DD16C,
+    "Who Lake": GrinchRegionInfo(0x12, "Mount Crumpit", True, 0x0DD16C,
         region_access=[
             [grinch_items.keys.WHO_LAKE],
             ["4:" + grinch_items.keys.PROGRESSIVE_VACUUM_TUBE],
         ],),
 
-    "Sleigh Room": GrinchRegionInfo(0x05, "Mount Crumpit", False, 0x800FAAF0, 0x800FAADB, 0x800FAAB4,
+    "Sleigh Room": GrinchRegionInfo(0x05, "Mount Crumpit", False, 0x0FAAB4,
         region_access=[
             [grinch_items.keys.SLEIGH_ROOM_KEY],
         ],),
@@ -93,34 +91,34 @@ ALL_REGIONS_INFO: dict[str, GrinchRegionInfo] = {
     "Spin N' Win": GrinchRegionInfo(0x1A, "Mount Crumpit", False),
     "Dankamania": GrinchRegionInfo(0x1B, "Mount Crumpit", False),
     "The Copter Race Contest": GrinchRegionInfo(0X1C, "Mount Crumpit", False),
-    "Post Office": GrinchRegionInfo(0x0A, "Whoville", False, 0x800DFBA0, 0x800DFB8B, 0x800DFB64,
+    "Post Office": GrinchRegionInfo(0x0A, "Whoville", False, 0x0DFB64,
         region_access=[
             [grinch_items.level_items.WV_WHO_CLOAK],
         ],),
 
-    "City Hall": GrinchRegionInfo(0x08, "Whoville", True, 0x800E70CC, 0x800E70B7, 0x800E7090,
+    "City Hall": GrinchRegionInfo(0x08, "Whoville", True, 0x0E7090,
         region_access=[
             [grinch_items.gadgets.ROTTEN_EGG_LAUNCHER],
         ],),
 
-    "Clock Tower": GrinchRegionInfo(0x09, "Whoville", False, 0x800E7124, 0x800E710F, 0x800E70E8,
+    "Clock Tower": GrinchRegionInfo(0x09, "Whoville", False, 0x0E70E8,
         region_access=[
             [grinch_items.moves.SNEAK],
             [grinch_items.gadgets.SLIME_SHOOTER],
         ],),
 
-    "Ski Resort": GrinchRegionInfo(0x0C, "Who Forest", True, 0x800E98FC, 0x800E98E7, 0x800E98C0,
+    "Ski Resort": GrinchRegionInfo(0x0C, "Who Forest", True, 0x0E98C0,
         region_access=[
             [grinch_items.level_items.WF_CABLE_CAR_ACCESS_CARD],
         ],),
 
-    "Civic Center": GrinchRegionInfo(0x0D, "Who Forest", True, 0x800DDEDC, 0x800DDEC7, 0x800DDEA0,
+    "Civic Center": GrinchRegionInfo(0x0D, "Who Forest", True, 0x0DDEA0,
         region_access=[
             [grinch_items.gadgets.GRINCH_COPTER],
             [grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE],
         ],),
 
-    "Minefield": GrinchRegionInfo(0x11, "Who Dump", True, 0x800E8800, 0x800E87EB, 0x800E87C4,
+    "Minefield": GrinchRegionInfo(0x11, "Who Dump", True, 0x0E87C4,
         region_access=[
             [grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
             grinch_items.gadgets.ROCKET_SPRING,
@@ -130,7 +128,7 @@ ALL_REGIONS_INFO: dict[str, GrinchRegionInfo] = {
             grinch_items.moves.PANCAKE],
         ],),
 
-    "Power Plant": GrinchRegionInfo(0x10, "Who Dump", True, 0x800E8898, 0x800E8883, 0x800E885C,
+    "Power Plant": GrinchRegionInfo(0x10, "Who Dump", True, 0x0E885C,
         region_access=[
             [grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
             grinch_items.gadgets.GRINCH_COPTER,
@@ -145,7 +143,7 @@ ALL_REGIONS_INFO: dict[str, GrinchRegionInfo] = {
             grinch_items.moves.PANCAKE],
         ],),
 
-    "Generator Building": GrinchRegionInfo(0x0F, "Power Plant", True, 0x800E0F10, 0x800E0EFB, 0x800E0ED4,
+    "Generator Building": GrinchRegionInfo(0x0F, "Power Plant", True, 0x0E0ED4,
         region_access=[
             [grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
             grinch_items.gadgets.GRINCH_COPTER],
@@ -156,12 +154,12 @@ ALL_REGIONS_INFO: dict[str, GrinchRegionInfo] = {
              grinch_items.moves.BAD_BREATH],
         ],),
 
-    "Submarine World": GrinchRegionInfo(0x17, "Who Lake", True, 0x800E03A4, 0X800E038F, 0x800E0368,
+    "Submarine World": GrinchRegionInfo(0x17, "Who Lake", True, 0x0E0368,
         region_access=[
             [grinch_items.gadgets.MARINE_MOBILE],
         ],),
 
-    "Scout's Hut": GrinchRegionInfo(0x16, "Who Lake", True, 0x800D5E38, 0x800D5E25, 0x800D5DFC,
+    "Scout's Hut": GrinchRegionInfo(0x16, "Who Lake", True, 0x0D5DFC,
         region_access=[
             [grinch_items.gadgets.GRINCH_COPTER,
             grinch_items.moves.SNEAK],
@@ -169,17 +167,17 @@ ALL_REGIONS_INFO: dict[str, GrinchRegionInfo] = {
             grinch_items.moves.SNEAK],
         ],),
 
-    "North Shore": GrinchRegionInfo(0x14, "Who Lake", True, 0x800DD478, 0x800DD463, 0x800DD43C,
+    "North Shore": GrinchRegionInfo(0x14, "Who Lake", True, 0x0DD43C,
         region_access=[
             [grinch_items.level_items.WL_SCOUT_CLOTHES,
             grinch_items.moves.SNEAK],
         ],),
-    "Mayor's Villa": GrinchRegionInfo(0x16, "North Shore", True, 0x800FA804, 0x800FA7EF, 0x800FA7C8,
+    "Mayor's Villa": GrinchRegionInfo(0x16, "North Shore", True, 0x0FA7C8,
         region_access=[
             [grinch_items.level_items.WL_SCOUT_CLOTHES],
         ],),
     "Bike Race": GrinchRegionInfo(0x18, "Sleigh Room", False),
-    "Sleigh Ride": GrinchRegionInfo(0x19, "Sleigh Room", False, 0x800E4FBC, 0x800E4FC0, None,
+    "Sleigh Ride": GrinchRegionInfo(0x19, "Sleigh Room", False, 0x0E4F99,
         region_access=[
             [grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
              grinch_items.keys.WHOVILLE,


### PR DESCRIPTION
Simplified Region class to only require the Region Table address. After manually checking, seems all health addresses are 0x3C off of the table start address and deathlink triggers are 0x27

These were initially flipped so I flipped them around. Additionally, they all started with 0x80, which was not a valid address in BizHawk (but would always return 0...)

Made DeathLink a class variable we use to know whether or not we need to be constantly monitoring Grinch's health. Added an if statement to check is health only when necessary.

Removed on_deathlink function in the client, as it was no longer necessary. Added a guard in place if the DeathLink was from self, to avoid triggering double deathlinks.

Made new functions to get region data and wait for grinch's death cutscene to complete.
Updated the existing kill_grinch and check_grinch_alive to follow consistent formats of new functions and fix silly mistakes

Current deathlink message sent to others is "Could not fight off the Christmas cheer...". This can be searched for and changed.