### PR TITLE
Update MM BP Logic

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -1054,9 +1054,9 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.moves.SNEAK,
         ],
         [
-            grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
-            grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
             grinch_items.moves.SNEAK,
+            grinch_items.moves.MAX,
         ],
     ],
     "WL - Scout's Hut - Steal Scout's Hat": [
@@ -2741,6 +2741,7 @@ rules_dict: dict[str, list[list[str]]] = {
         [
             grinch_items.level_items.WL_SCOUT_CLOTHES,
             grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.moves.SEIZE,
             grinch_items.moves.MAX,
             grinch_items.moves.SNEAK,
         ],


### PR DESCRIPTION
WL - North Shore - MM BP inside Boulder Box near Bridge and
WL - North Shore - MM BP inside Boulder Box behind Skunk Hut both require Seize, but the first logical set for
WL - Collect all Marine Mobile Blueprints
does not include Seize.  This adds Seize to that set.

Max can easily get by the Summer Beast to obtain
WL - South Shore - MM BP behind Summer Beast
This adds (OCD and Sneak and Max) as a logical option for WL - South Shore - MM BP behind Summer Beast. (The second logical set for
WL - Collect all Marine Mobile Blueprints
did not include enough items to put
WL - South Shore - MM BP behind Summer Beast
in logic with the previous logic, but this new option is already covered by the existing logic.  If this Max option were not to be added, the WL - Collect all Marine Mobile Blueprints logic would need to be changed.)

Finally, the logical set of (REL and GC and Sneak) for WL - South Shore - MM BP behind Summer Beast is redundant with (GC and Sneak), and has been removed for simplicity.