### PR TITLE
Add ADVANCED_LOGIC to Modifying The Mayor's Statue

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -158,6 +158,7 @@ rules_dict: dict[str, list[list[str]]] = {
         ],
         [
             grinch_items.events.MISSION_ITEMS_NOT_RANDOMIZED,
+            grinch_items.events.ADVANCED_LOGIC,
             grinch_items.gadgets.SLIME_SHOOTER,
             grinch_items.moves.SEIZE,
             grinch_items.moves.PANCAKE,


### PR DESCRIPTION
Since the set of (Sculpting Tools and Slime Shooter) is in advanced logic, it seems like (MISSION_ITEMS_NOT_RANDOMIZED and Slime Shooter and Seize and Pancake) should also be in advanced logic.