### PR TITLE
Re-add SLIME_SHOOTER to Advancing The Countdown-To-Xmas Clock

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -169,6 +169,7 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.gadgets.ROCKET_SPRING,
             grinch_items.moves.SEIZE,
             grinch_items.moves.MAX,
+            grinch_items.gadgets.SLIME_SHOOTER,
         ],
         [
             grinch_items.level_items.WV_HAMMER,


### PR DESCRIPTION
Since the set of (Sculpting Tools and Slime Shooter) is in advanced logic, it seems like (MISSION_ITEMS_NOT_RANDOMIZED and Slime Shooter and Seize and Pancake) should also be in advanced logic.