### PR TITLE
Remove ROCKET_SPRING and add PANCAKE, SNEAK moves

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -528,9 +528,10 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.events.MISSION_ITEMS_NOT_RANDOMIZED,
             grinch_items.moves.BAD_BREATH,
             grinch_items.gadgets.GRINCH_COPTER,
-            grinch_items.gadgets.ROCKET_SPRING,
             grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
             grinch_items.moves.MAX,
+            grinch_items.moves.PANCAKE,
+            grinch_items.moves.SNEAK,
         ],
     ],
     "WL - Squashing All Gifts": [


### PR DESCRIPTION
Fixes the logical requirements for Hooking The Mayor's Bed To The Motorboat when mission items are not randomized.