### PR TITLE
Remove ADVANCED_LOGIC from Swinging pipe in left area pipe

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -2514,7 +2514,6 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.moves.PANCAKE,
         ],
         [
-            grinch_items.events.ADVANCED_LOGIC,
             grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
             grinch_items.gadgets.GRINCH_COPTER,
             grinch_items.moves.PANCAKE,


### PR DESCRIPTION
Removed ADVANCED_LOGIC from WD - Conducting The Stinky Gas To Who-Bris' Shack - Swinging pipe in left area pipe, as there is nothing advanced about that logical path.