### PR TITLE
Add SEIZE move to Collect all Marine Mobile Blueprints

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -3337,6 +3337,7 @@ rules_dict: dict[str, list[list[str]]] = {
         [
             grinch_items.level_items.WL_SCOUT_CLOTHES,
             grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.moves.SEIZE,
             grinch_items.moves.MAX,
             grinch_items.moves.SNEAK,
         ],
@@ -3352,6 +3353,7 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.events.ADVANCED_LOGIC,
             grinch_items.level_items.WL_SCOUT_CLOTHES,
             grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.moves.SEIZE,
             grinch_items.moves.MAX,
         ],
         [
@@ -3365,6 +3367,7 @@ rules_dict: dict[str, list[list[str]]] = {
         [
             grinch_items.events.MISSION_ITEMS_NOT_RANDOMIZED,
             grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.moves.SEIZE,
             grinch_items.moves.MAX,
             grinch_items.moves.SNEAK,
             grinch_items.moves.BAD_BREATH,
@@ -3385,6 +3388,7 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.events.ADVANCED_LOGIC,
             grinch_items.level_items.WL_SCOUT_CLOTHES,
             grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.moves.SEIZE,
             grinch_items.moves.MAX,
             grinch_items.moves.BAD_BREATH,
             grinch_items.moves.PANCAKE,


### PR DESCRIPTION
Seize should be a hard requirement for WL - Collect all Marine Mobile Blueprints because of the two BPs inside boulder boxes.  It was only on half of the logical sets.  This adds it to the other half.

(It seems like Seize was only considered for MM BP on Grass Platform.  Seize can be skipped with GC for that one, but not for the two in the boulder boxes as far as I know.)