### PR TITLE
Add advanced logic to OCD BP near Who-Bris' Shack

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -1032,7 +1032,14 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.gadgets.ROCKET_SPRING,
             grinch_items.moves.PANCAKE,
             grinch_items.moves.SEIZE,
-        ]
+        ],
+        [
+            grinch_items.events.ADVANCED_LOGIC,
+            grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+            grinch_items.moves.PANCAKE,
+            grinch_items.moves.SEIZE,
+        ],
     ],
     "WD - Minefield - OCD BP on Left Side of House": [
         [


### PR DESCRIPTION
The logic for WD - OCD BP near Who-Bris' Shack should stay the same as WD - Conducting The Stinky Gas To Who-Bris' Shack.  This just adds the advanced logic that was already added to that.