### PR TITLE
Add advanced logic to Seizing pipe in rat area

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -2463,6 +2463,20 @@ rules_dict: dict[str, list[list[str]]] = {
             grinch_items.moves.PANCAKE,
             grinch_items.moves.SEIZE,
         ],
+        [
+            grinch_items.events.ADVANCED_LOGIC,
+            grinch_items.gadgets.SLIME_SHOOTER,
+            grinch_items.gadgets.ROCKET_SPRING,
+            grinch_items.moves.PANCAKE,
+            grinch_items.moves.SEIZE,
+        ],
+        [
+            grinch_items.events.ADVANCED_LOGIC,
+            grinch_items.gadgets.SLIME_SHOOTER,
+            grinch_items.gadgets.GRINCH_COPTER,
+            grinch_items.moves.PANCAKE,
+            grinch_items.moves.SEIZE,
+        ],
     ],
     "WD - Conducting The Stinky Gas To Who-Bris' Shack - Shooting pipe in right side inside pipe": [
         [


### PR DESCRIPTION
This adds the advanced logic of using Slime Shooter instead of Rotten Egg Launcher to get WD - Conducting The Stinky Gas To Who-Bris' Shack - Seizing pipe in rat area (and using the book to get back).