### PR TITLE
Fix Minefield advanced logic

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -430,8 +430,28 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
         ],
         advanced_location_access=[
             [
-                grinch_items.moves.PANCAKE,
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
                 grinch_items.gadgets.ROCKET_SPRING,
+                grinch_items.moves.SNEAK,
+                grinch_items.level_items.WD_SCISSORS,
+            ],
+            [
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
+                grinch_items.moves.PANCAKE,
+                grinch_items.moves.SNEAK,
+                grinch_items.level_items.WD_SCISSORS,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.gadgets.ROCKET_SPRING,
+                grinch_items.moves.SNEAK,
+                grinch_items.level_items.WD_SCISSORS,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.moves.PANCAKE,
                 grinch_items.moves.SNEAK,
                 grinch_items.level_items.WD_SCISSORS,
             ],
@@ -1177,8 +1197,12 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
         ],
         advanced_location_access=[
             [
-                grinch_items.moves.PANCAKE,
+                grinch_items.gadgets.SLIME_SHOOTER,
                 grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.moves.PANCAKE,
             ],
         ],
     ),
@@ -1195,8 +1219,22 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
         ],
         advanced_location_access=[
             [
-                grinch_items.moves.PANCAKE,
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
                 grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
+                grinch_items.moves.PANCAKE,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.moves.PANCAKE,
             ],
         ],
     ),
@@ -1216,8 +1254,12 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
         ],
         advanced_location_access=[
             [
-                grinch_items.moves.PANCAKE,
+                grinch_items.gadgets.SLIME_SHOOTER,
                 grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.moves.PANCAKE,
             ],
         ],
     ),
@@ -1625,8 +1667,22 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
         ],
         advanced_location_access=[
             [
-                grinch_items.moves.PANCAKE,
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
                 grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
+                grinch_items.moves.PANCAKE,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.moves.PANCAKE,
             ],
         ],
     ),
@@ -4538,8 +4594,22 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
         ],
         advanced_location_access=[
             [
-                grinch_items.moves.PANCAKE,
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
                 grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.moves.MAX,
+                grinch_items.moves.PANCAKE,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.gadgets.ROCKET_SPRING,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.moves.PANCAKE,
             ],
         ],
     ),


### PR DESCRIPTION
Generic Minefield logic will be:
Normal logic: GC or (REL, SS, RS)
Advanced logic: (REL or SS) 🛏️ and (SS or Max) 🤖 and (RS or Pancake) 🦘 (🛏️ is for shooting down mattresses, 🤖 is for neutralizing the robot who shoots at you, and 🦘 is for crossing the platforms themselves.) which expands to:
Advanced logic: (REL, SS, RS) or (REL, SS, Pancake) or (REL, Max, RS) or (REL, Max, Pancake) or (SS, RS) or (SS, Pancake) The first case is covered by normal logic.  The first two are redundant with the last two.  That leaves: Advanced logic: (REL, Max, RS) or (REL, Max, Pancake) or (SS, RS) or (SS, Pancake)

Then Max-only checks and Sneak/Scissors checks modify things further.