### PR TITLE
Fix/update ice cave logic

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -993,6 +993,19 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
                 grinch_items.moves.BAD_BREATH,
             ],
         ],
+        advanced_location_access=[
+            [
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
+                grinch_items.moves.PANCAKE,
+                grinch_items.moves.BAD_BREATH,
+            ],
+            [
+                grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
+                grinch_items.moves.PANCAKE,
+                grinch_items.moves.SNEAK,
+            ],
+        ],
     ),
     "WF - Civic Center - GC BP in Frozen Ice": GrinchLocationInfo(
         location_access=[
@@ -1030,6 +1043,19 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
                 grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
                 grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
                 grinch_items.moves.PANCAKE,
+                grinch_items.moves.BAD_BREATH,
+            ],
+            [
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
+                grinch_items.moves.PANCAKE,
+                grinch_items.moves.SNEAK,
+            ],
+            [
+                grinch_items.gadgets.SLIME_SHOOTER,
+                grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
+                grinch_items.moves.PANCAKE,
+                grinch_items.moves.SNEAK,
             ],
         ],
     ),
@@ -2465,13 +2491,6 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
                 grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
                 grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
                 grinch_items.gadgets.ROCKET_SPRING,
-                grinch_items.gadgets.SLIME_SHOOTER,
-                grinch_items.moves.BAD_BREATH,
-            ],
-            [
-                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
-                grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
-                grinch_items.gadgets.ROCKET_SPRING,
                 grinch_items.moves.SNEAK,
                 grinch_items.moves.BAD_BREATH,
             ],
@@ -2530,6 +2549,13 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
                 grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
                 grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
                 grinch_items.gadgets.ROCKET_SPRING,
+            ],
+        ],
+        advanced_location_access=[
+            [
+                grinch_items.gadgets.ROTTEN_EGG_LAUNCHER,
+                grinch_items.gadgets.OCTOPUS_CLIMBING_DEVICE,
+                grinch_items.moves.PANCAKE,
             ],
         ],
     ),


### PR DESCRIPTION
The normal logic for WF - Civic Center - Replacing The Candles On The Cake With Fireworks - Across tree branch swinging platform looks like a mistake.  It seems to be expecting going through the cave, which needs Sneak, which already exists as a different logical set.

This expands the recently added advanced logic for ascending the ice cave exit ramp with pancake and first person view, applying the route to more checks and adding the need for BB to take out the guard when using the exit (since he spawns when breaking the exit wall and despawns when leaving the region).