### PR TITLE
Supadow minigames ! (And other fixes)

### DIFF
--- a/worlds/grinch/Client.py
+++ b/worlds/grinch/Client.py
@@ -8,7 +8,7 @@ import copy
 import uuid
 import Utils
 from BaseClasses import ItemClassification
-from worlds.grinch.RamHandler import UpdateMethod
+from worlds.grinch.RamHandler import UpdateMethod, GrinchRamVariables
 from . import MOVES_TABLE
 from .Locations import grinch_locations, GrinchLocation
 from .Items import (
@@ -101,7 +101,7 @@ class GrinchClient(BizHawkClient):
     chosen_music: dict = {}
     randomize_mission_items: bool = False
     randomize_sleigh_parts: bool = False
-    supadow_minigames: bool = False
+    supadow_minigames: int = 0
     #yes
 
     def __init__(self):
@@ -116,7 +116,7 @@ class GrinchClient(BizHawkClient):
         self.teleport_multibind = False
         self.randomize_mission_items = False
         self.randomize_sleigh_parts = False
-        self.supadow_minigames = False
+        self.supadow_minigames = 0
 
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         from CommonClient import logger
@@ -244,7 +244,7 @@ class GrinchClient(BizHawkClient):
         from CommonClient import logger
 
         # If the player is not connected to an AP Server, or their connection was disconnected.
-        if not ctx.slot:
+        if ctx.server is None or ctx.server.socket.closed or ctx.slot_data is None or ctx.auth is None:
             return
 
         try:
@@ -264,6 +264,7 @@ class GrinchClient(BizHawkClient):
             await self.goal_checker(ctx)
             await self.option_handler(ctx)
             await self.constant_address_update(ctx)
+            await self.supadow_handler(ctx)
             # await self.funny_secret_goal(ctx)
             #await self.adjust_damage_rate(ctx)
 
@@ -320,13 +321,26 @@ class GrinchClient(BizHawkClient):
                     (addr_to_update.ram_address, addr_to_update.byte_size, "MainRAM")
                 )
                 value_read_from_bizhawk: int = int.from_bytes(returned_bytes[orig_index], "little")
-
                 if is_binary:
                     ram_checked_list.append((value_read_from_bizhawk & (1 << addr_to_update.binary_bit_pos)) > 0)
 
                 else:
-                    expected_int_value = addr_to_update.value
-                    ram_checked_list.append(expected_int_value == value_read_from_bizhawk)
+                    # If there is a MIN and a MAX, take these values instead to check the locations
+                    # If a MIN is there and no MAX, treat the location as completed when Min is correct and within MAX depending on byte size
+                    if addr_to_update.min_count and not addr_to_update.max_count:
+                        expected_min_value = addr_to_update.min_count
+                        expected_max_value = (1 << (addr_to_update.byte_size * 8)) - 1
+                    # If there is a min and a max, check for between the boundaries
+                    elif addr_to_update.min_count and addr_to_update.max_count:
+                        expected_min_value = addr_to_update.min_count
+                        expected_max_value = addr_to_update.max_count
+                    # If on "value" is present, set min and max to to only look for exact value
+                    else:
+                        expected_min_value = addr_to_update.value
+                        expected_max_value = addr_to_update.value
+                    ram_checked_list.append(expected_min_value <= value_read_from_bizhawk <= expected_max_value)
+
+
 
             if all(ram_checked_list):
                 local_locations_checked.append(GrinchLocation.get_apid(grinch_loc_ram_data.id))
@@ -484,6 +498,89 @@ class GrinchClient(BizHawkClient):
 
         return addr_list_to_update
 
+    async def supadow_handler(self, ctx: "BizHawkClientContext"):
+        # When in MC
+        list_recv_itemids: list[int] = [netItem.item for netItem in ctx.items_received]
+        SpinNWinReceived = (42069 + ALL_ITEMS_TABLE[grinch_items.supadow.SPIN_N_WIN].id) in list_recv_itemids
+        PankamaniaReceived = (42069 + ALL_ITEMS_TABLE[grinch_items.supadow.PANKAMANIA].id) in list_recv_itemids
+        CopterRaceReceived = (42069 + ALL_ITEMS_TABLE[grinch_items.supadow.COPTER_RACE].id) in list_recv_itemids
+
+        ingame_map_id = await self.get_current_map_id(ctx)
+
+        SupadowReads = []
+        SupadowWrites = []
+
+        if ingame_map_id == ALL_REGIONS_INFO["Mount Crumpit"].map_id:
+
+            SupadowReads += [(GrinchRamVariables.SpinNWinDoor["OpenTextGiftNum"], 2, "MainRAM")]
+            SupadowReads += [(GrinchRamVariables.SpinNWinDoor["AllowInteractGiftNum"], 2, "MainRAM")]
+            SupadowReads += [(GrinchRamVariables.SpinNWinDoor["LockedTextGiftNum"], 2, "MainRAM")]
+
+            SupadowReads += [(GrinchRamVariables.PankamaniaDoor["OpenTextGiftNum"], 2, "MainRAM")]
+            SupadowReads += [(GrinchRamVariables.PankamaniaDoor["AllowInteractGiftNum"], 2, "MainRAM")]
+            SupadowReads += [(GrinchRamVariables.PankamaniaDoor["LockedTextGiftNum"], 2, "MainRAM")]
+
+            SupadowReads += [(GrinchRamVariables.GCContestDoor["OpenTextGiftNum"], 2, "MainRAM")]
+            SupadowReads += [(GrinchRamVariables.GCContestDoor["AllowInteractGiftNum"], 2, "MainRAM")]
+            SupadowReads += [(GrinchRamVariables.GCContestDoor["LockedTextGiftNum"], 2, "MainRAM")]
+            reads = await bizhawk.read(ctx.bizhawk_ctx, SupadowReads)
+
+            SpinNWinDoor_OpenTextGiftNum = int.from_bytes(reads[0])
+            SpinNWinDoor_AllowInteractGiftNum = int.from_bytes(reads[1])
+            SpinNWinDoor_LockedTextGiftNum = int.from_bytes(reads[2])
+            PankamaniaDoor_OpenTextGiftNum = int.from_bytes(reads[3])
+            PankamaniaDoor_AllowInteractGiftNum = int.from_bytes(reads[4])
+            PankamaniaDoor_LockedTextGiftNum = int.from_bytes(reads[5])
+
+            GCContestDoor_OpenTextGiftNum = int.from_bytes(reads[6])
+            GCContestDoor_AllowInteractGiftNum = int.from_bytes(reads[7])
+            GCContestDoor_LockedTextGiftNum = int.from_bytes(reads[8])
+
+            if SpinNWinReceived:
+                if SpinNWinDoor_OpenTextGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.SpinNWinDoor["OpenTextGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+                if SpinNWinDoor_AllowInteractGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.SpinNWinDoor["AllowInteractGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+                if SpinNWinDoor_LockedTextGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.SpinNWinDoor["LockedTextGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+            else:
+                if SpinNWinDoor_OpenTextGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.SpinNWinDoor["OpenTextGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+                if SpinNWinDoor_AllowInteractGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.SpinNWinDoor["AllowInteractGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+                if SpinNWinDoor_LockedTextGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.SpinNWinDoor["LockedTextGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+            if PankamaniaReceived:
+                if PankamaniaDoor_OpenTextGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.PankamaniaDoor["OpenTextGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+                if PankamaniaDoor_AllowInteractGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.PankamaniaDoor["AllowInteractGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+                if PankamaniaDoor_LockedTextGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.PankamaniaDoor["LockedTextGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+            else:
+                if PankamaniaDoor_OpenTextGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.PankamaniaDoor["OpenTextGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+                if PankamaniaDoor_AllowInteractGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.PankamaniaDoor["AllowInteractGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+                if PankamaniaDoor_LockedTextGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.PankamaniaDoor["LockedTextGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+            if CopterRaceReceived:
+                if GCContestDoor_OpenTextGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.GCContestDoor["OpenTextGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+                if GCContestDoor_AllowInteractGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.GCContestDoor["AllowInteractGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+                if GCContestDoor_LockedTextGiftNum != 0x0000:
+                    SupadowWrites += [(GrinchRamVariables.GCContestDoor["LockedTextGiftNum"], 0x0000.to_bytes(2, "little"), "MainRAM")]
+            else:
+                if GCContestDoor_OpenTextGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.GCContestDoor["OpenTextGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+                if GCContestDoor_AllowInteractGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.GCContestDoor["AllowInteractGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+                if GCContestDoor_LockedTextGiftNum != 0xFFFF:
+                    SupadowWrites += [(GrinchRamVariables.GCContestDoor["LockedTextGiftNum"], 0xFFFF.to_bytes(2, "little"), "MainRAM")]
+            if SupadowWrites:
+                await bizhawk.write(ctx.bizhawk_ctx,SupadowWrites)
+
     # Removes the regional access until you actually received it from AP.
     async def constant_address_update(self, ctx: "BizHawkClientContext"):
         ram_addr_dict: dict[int, list[int]] = {}
@@ -561,11 +658,11 @@ class GrinchClient(BizHawkClient):
                 continue
 
             if (item_name in [grinch_items.supadow.SPIN_N_WIN,
-                grinch_items.supadow.DANKAMANIA,
+                grinch_items.supadow.PANKAMANIA,
                 grinch_items.supadow.COPTER_RACE,
                 grinch_items.supadow.BIKE_RACE]
                 and (ingame_map_id != 0x05
-                or not self.supadow_minigames)):
+                or self.supadow_minigames == 0)):
                 continue
 
             # This will either constantly update the item to ensure you still have it or take it away if you don't deserve it

--- a/worlds/grinch/GrinchOptions.py
+++ b/worlds/grinch/GrinchOptions.py
@@ -153,13 +153,19 @@ class ProgressiveGadgets(Toggle):  # DefaultOnToggle
     visibility = Visibility.none
 
 
-class Supadow(Toggle):
+class Supadow(Choice):
     """
     Enables completing minigames through the Supadows in Mount Crumpit as checks.
+    NOTE: Each difficulty will need to be played separately.
+    These are not mixed with other difficulties for how locations get checked
     """
 
     display_name = "Supadow Minigames"
-    visibility = Visibility.none
+    option_none = 0
+    option_easy = 1
+    option_hard = 2
+    option_real_tough = 3
+    default = 0
 
 
 class Gifts(Toggle):

--- a/worlds/grinch/Items.py
+++ b/worlds/grinch/Items.py
@@ -104,7 +104,7 @@ class grinch_items:
 
     class supadow:
         SPIN_N_WIN: str = "Spin N' Win Supadow"
-        DANKAMANIA: str = "Dankamania Supadow"
+        PANKAMANIA: str = "Pankamania Supadow"
         COPTER_RACE: str = "The Copter Race Contest Supadow"
         PROGRESSIVE_SUPADOW: str = "Progressive Supadow"
         BIKE_RACE: str = "Bike Race Unlock"
@@ -562,15 +562,15 @@ SUPADOW_TABLE: dict[str, GrinchItemData] = {
         ],
         405,
         IC.progression_skip_balancing,
-        [GrinchRamData()],
+        [],
     ),
-    grinch_items.supadow.DANKAMANIA: GrinchItemData(
+    grinch_items.supadow.PANKAMANIA: GrinchItemData(
         [
             grinch_categories.SUPADOW_MINIGAMES,
         ],
         406,
         IC.progression_skip_balancing,
-        [GrinchRamData()],
+        [],
     ),
     grinch_items.supadow.COPTER_RACE: GrinchItemData(
         [
@@ -578,7 +578,7 @@ SUPADOW_TABLE: dict[str, GrinchItemData] = {
         ],
         407,
         IC.progression_skip_balancing,
-        [GrinchRamData()],
+        [],
     ),
     grinch_items.supadow.BIKE_RACE: GrinchItemData(
         [
@@ -586,7 +586,7 @@ SUPADOW_TABLE: dict[str, GrinchItemData] = {
         ],
         408,
         IC.progression_skip_balancing,
-        [GrinchRamData()],
+        [],
     ),
     # grinch_items.supadow.PROGRESSIVE_SUPADOW: GrinchItemData(
     #     [

--- a/worlds/grinch/Locations.py
+++ b/worlds/grinch/Locations.py
@@ -1254,64 +1254,156 @@ grinch_locations = {
     # Supadow Minigames
     "Spin N' Win - Easy": GrinchLocationData(
         "Spin N' Win",
-        ["Supadow Minigames", "Spin N' Win"],
+        ["Supadow Minigames", "Spin N' Win", "Supadow Easy"],
         1500,
-        [GrinchRamData(0x0100FD, min_count=1, max_count=59)]),
+        [
+                        #GrinchRamData(0x0100B3, min_count=1, max_count=59),
+                        GrinchRamData(0x010000, value=26),
+                        GrinchRamData(0x095346, value=0),
+                        GrinchRamData(0x08F9D0, value=71)]),
     "Spin N' Win - Hard": GrinchLocationData(
         "Spin N' Win",
-        ["Supadow Minigames", "Spin N' Win"],
+        ["Supadow Minigames", "Spin N' Win", "Supadow Hard"],
         1501,
-        [GrinchRamData(0x0100FD, min_count=1, max_count=44)]),
+        [
+                        #GrinchRamData(0x0100B3, min_count=1, max_count=44),
+                        GrinchRamData(0x010000, value=26),
+                        GrinchRamData(0x095346, value=1),
+                        GrinchRamData(0x08F9D0, value=71)]),
     "Spin N' Win - Real Tough": GrinchLocationData(
         "Spin N' Win",
-        ["Supadow Minigames", "Spin N' Win"],
+        ["Supadow Minigames", "Spin N' Win", "Supadow Real Tough"],
         1502,
-        [GrinchRamData(0x0100FD, min_count=1, max_count=29)]),
-    "Dankamania - 12 Points": GrinchLocationData(
-        "Dankamania",
-        ["Supadow Minigames", "Dankamania"],
+        [
+                        #GrinchRamData(0x0100B3, min_count=1, max_count=29),
+                        GrinchRamData(0x010000, value=26),
+                        GrinchRamData(0x095346, value=2),
+                        GrinchRamData(0x08F9D0, value=71)]),
+    "Pankamania - Easy - 4 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Easy"],
         1503,
-        [GrinchRamData(0x0100FB, min_count=12)]),
+        [
+                        GrinchRamData(0x0100EB,value=4, min_count=4, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=0)]),
+    "Pankamania - Easy - 8 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Easy"],
+        1504,
+        [
+                        GrinchRamData(0x0100EB,value=8, min_count=8, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=0)]),
+    "Pankamania - Easy - 12 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Easy"],
+        1505,
+        [
+                        GrinchRamData(0x0100EB, value=12, min_count=12, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=0)]),
+    "Pankamania - Hard - 4 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Hard"],
+        1506,
+        [
+                        GrinchRamData(0x0100EB, value=4, min_count=4, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=1)]),
+    "Pankamania - Hard - 8 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Hard"],
+        1507,
+        [
+                        GrinchRamData(0x0100EB, value=8, min_count=8, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=1)]),
+    "Pankamania - Hard - 12 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Hard"],
+        1508,
+        [
+                        GrinchRamData(0x0100EB, value=12, min_count=12, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=1)]),
+    "Pankamania - Real Tough - 4 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Real Tough"],
+        1509,
+        [
+                        GrinchRamData(0x0100EB, value=4, min_count=4, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=2)]),
+    "Pankamania - Real Tough - 8 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Real Tough"],
+        1510,
+        [
+                        GrinchRamData(0x0100EB, value=8, min_count=8, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=2)]),
+    "Pankamania - Real Tough - 12 Points": GrinchLocationData(
+        "Pankamania",
+        ["Supadow Minigames", "Pankamania", "Supadow Real Tough"],
+        1511,
+        [
+                        GrinchRamData(0x0100EB, value=12, min_count=12, max_count=99),
+                        GrinchRamData(0x010000, value=27),
+                        GrinchRamData(0x095346, value=2)]),
+
     "The Copter Race Contest - Easy": GrinchLocationData(
         "The Copter Race Contest",
-        ["Supadow Minigames", "The Copter Race Contest"],
-        1504,
-        [GrinchRamData(0x0100FC, min_count=1, max_count=44)]),
+        ["Supadow Minigames", "The Copter Race Contest", "Supadow Easy"],
+        1512,
+        [
+                        #GrinchRamData(0x0100B3, min_count=1, max_count=44),
+                        GrinchRamData(0x095345, value=0),
+                        GrinchRamData(0x010000, value=28),
+                        GrinchRamData(0x08F9D0, value=71)]),
     "The Copter Race Contest - Hard": GrinchLocationData(
         "The Copter Race Contest",
-        ["Supadow Minigames", "The Copter Race Contest"],
-        1505,
-        [GrinchRamData(0x0100FC, min_count=1, max_count=34)]),
+        ["Supadow Minigames", "The Copter Race Contest", "Supadow Hard"],
+        1513,
+        [
+                        #GrinchRamData(0x0100B3, min_count=1, max_count=34),
+                        GrinchRamData(0x095345, value=1),
+                        GrinchRamData(0x010000, value=28),
+                        GrinchRamData(0x08F9D0, value=71)]),
     "The Copter Race Contest - Real Tough": GrinchLocationData(
         "The Copter Race Contest",
-        ["Supadow Minigames", "The Copter Race Contest"],
-        1506,
-        [GrinchRamData(0x0100FC, min_count=1, max_count=29)]),
+        ["Supadow Minigames", "The Copter Race Contest", "Supadow Real Tough"],
+        1514,
+        [
+                        #GrinchRamData(0x0100B3, min_count=1, max_count=29),
+                        GrinchRamData(0x095345, value=2),
+                        GrinchRamData(0x010000, value=28),
+                        GrinchRamData(0x08F9D0, value=71)]),
     "Bike Race - 1st Place":  GrinchLocationData(
         "Bike Race",
-        ["Supadow Minigames", "Bike Race"],
-        1509,
+        ["Supadow Minigames", "Bike Race", "Supadow Real Tough"],
+        1515,
         [
             GrinchRamData(0x010000, value=0x18),
             GrinchRamData(0x134CA5, value=1)]),
     "Bike Race - Top 2": GrinchLocationData(
         "Bike Race",
-        ["Supadow Minigames", "Bike Race"],
-        1510,
+        ["Supadow Minigames", "Bike Race", "Supadow Hard"],
+        1516,
         [
             GrinchRamData(0x010000, value=0x18),
             GrinchRamData(0x134CA5, min_count=1, max_count=2)]),
     "Bike Race - Top 3": GrinchLocationData(
         "Bike Race",
-        ["Supadow Minigames", "Bike Race"],
-        1511,
+        ["Supadow Minigames", "Bike Race", "Supadow Easy"],
+        1517,
         [
             GrinchRamData(0x010000, value=0x18),
             GrinchRamData(0x134CA5, min_count=1, max_count=3)]),
     "Bike Race - Top 4": GrinchLocationData(
         "Bike Race",
-        ["Supadow Minigames", "Bike Race"],
-        1512,
+        ["Supadow Minigames", "Bike Race", "Supadow Easy"],
+        1518,
         [
             GrinchRamData(0x010000, value=0x18),
             GrinchRamData(0x134CA5, min_count=1, max_count=4)]),

--- a/worlds/grinch/RamHandler.py
+++ b/worlds/grinch/RamHandler.py
@@ -8,6 +8,23 @@ class UpdateMethod(IntEnum, boundary=STRICT):
     SUBTRACT = 3
     FREEZE = 4  # Currently Non-functional
 
+class GrinchRamVariables:
+    SpinNWinDoor = {
+        "OpenTextGiftNum": 0x12AF3C,
+        "AllowInteractGiftNum": 0x12AF54,
+        "LockedTextGiftNum": 0x12AF70
+    }
+    PankamaniaDoor = {
+        "OpenTextGiftNum": 0x12B038,
+        "AllowInteractGiftNum": 0x12B04A,
+        "LockedTextGiftNum": 0x12B066
+    }
+    GCContestDoor = {
+        "OpenTextGiftNum": 0x12AFBC,
+        "AllowInteractGiftNum": 0x12AFCE,
+        "LockedTextGiftNum": 0x12AFEA
+    }
+
 
 class GrinchRamData:
     """A Representation of an update to RAM data for The Grinch.
@@ -71,20 +88,20 @@ class GrinchRamData:
         # Error Handling
         if self.value and self.value > self.max_count:
             raise ValueError(
-                f"Value passed in is greater than max_count.\n\nRAM Address: {self.ram_address}\nValue: {self.value}" +
+                f"Value passed in is greater than max_count.\n\nRAM Address: {hex(self.ram_address)}\nValue: {self.value}" +
                 f"\nMax Count: {self.max_count}"
             )
 
         if self.value and self.value < self.min_count:
             raise ValueError(
-                f"Value passed in is lower than min_count.\n\nRAM Address: {self.ram_address}\nValue: {self.value}" +
-                f"\nMin Count: {self.max_count}"
+                f"Value passed in is lower than min_count.\n\nRAM Address: {hex(self.ram_address)}\nValue: {self.value}" +
+                f"\nMin Count: {self.min_count}"
             )
 
         if self.min_count > self.max_count:
             raise ValueError(
-                f"Max_cout passed in is lower than min_count.\n\nRAM Address: {self.ram_address}\nValue: {self.value}" +
-                f"\nMin Count: {self.max_count}\nMax Count: {self.max_count}"
+                f"Max_count passed in is lower than min_count.\n\nRAM Address: {hex(self.ram_address)}\nValue: {self.value}" +
+                f"\nMin Count: {self.min_count}\nMax Count: {self.max_count}"
             )
 
         if self.binary_bit_pos and self.update_method not in [UpdateMethod.SET, UpdateMethod.FREEZE]:

--- a/worlds/grinch/Regions.py
+++ b/worlds/grinch/Regions.py
@@ -36,7 +36,7 @@ subareas_list = [
 
 supadow_list = [
     "Spin N' Win Supadow",
-    "Dankamania Supadow",
+    "Pankamania Supadow",
     "The Copter Race Contest Supadow",
     "Bike Race",
 ]
@@ -94,9 +94,9 @@ ALL_REGIONS_INFO: dict[str, GrinchRegionInfo] = {
             [grinch_items.supadow.SPIN_N_WIN],
         ],),
 
-    "Dankamania": GrinchRegionInfo(0x1B, "Mount Crumpit", False, allow_music_rando=True,
+    "Pankamania": GrinchRegionInfo(0x1B, "Mount Crumpit", False, allow_music_rando=True,
        region_access=[
-           [grinch_items.supadow.DANKAMANIA],
+           [grinch_items.supadow.PANKAMANIA],
        ],),
 
     "The Copter Race Contest": GrinchRegionInfo(0X1C, "Mount Crumpit", False, allow_music_rando=True,

--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -1734,17 +1734,47 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
             [],
         ],
     ),
-    "Dankamania - Easy - 15 Points": GrinchLocationInfo(
+    "Pankamania - Easy - 4 Points": GrinchLocationInfo(
         location_access=[
             [],
         ],
     ),
-    "Dankamania - Hard - 15 Points": GrinchLocationInfo(
+    "Pankamania - Easy - 8 Points": GrinchLocationInfo(
         location_access=[
             [],
         ],
     ),
-    "Dankamania - Real Tough - 15 Points": GrinchLocationInfo(
+    "Pankamania - Easy - 12 Points": GrinchLocationInfo(
+        location_access=[
+            [],
+        ],
+    ),
+    "Pankamania - Hard - 4 Points": GrinchLocationInfo(
+        location_access=[
+            [],
+        ],
+    ),
+    "Pankamania - Hard - 8 Points": GrinchLocationInfo(
+        location_access=[
+            [],
+        ],
+    ),
+    "Pankamania - Hard - 12 Points": GrinchLocationInfo(
+        location_access=[
+            [],
+        ],
+    ),
+    "Pankamania - Real Tough - 4 Points": GrinchLocationInfo(
+        location_access=[
+            [],
+        ],
+    ),
+    "Pankamania - Real Tough - 8 Points": GrinchLocationInfo(
+        location_access=[
+            [],
+        ],
+    ),
+    "Pankamania - Real Tough - 12 Points": GrinchLocationInfo(
         location_access=[
             [],
         ],
@@ -1775,6 +1805,11 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
         ],
     ),
     "Bike Race - Top 3": GrinchLocationInfo(
+        location_access=[
+            [],
+        ],
+    ),
+    "Bike Race - Top 4": GrinchLocationInfo(
         location_access=[
             [],
         ],

--- a/worlds/grinch/__init__.py
+++ b/worlds/grinch/__init__.py
@@ -131,6 +131,10 @@ class GrinchWorld(World):
                 region.add_event(location, "Goal", None, Location, Item)
                 continue
 
+            #Exclude bike races for now, since they are not accessible
+            if "Bike Race -" in location:
+                continue
+
             # No .value after self.options because UT no likey
             if location == "MC - Unlock the Grinch Copter" and self.options.exclude_gc:
                 continue
@@ -185,10 +189,15 @@ class GrinchWorld(World):
 
                 if exclude_wl_squash:
                     continue  # Ignores the creation of WL Squashing all Gifts
-
-            if "Supadow Minigames" in data.location_group and not self.options.supadow_minigames:
+            if "Supadow Minigames" in data.location_group and self.options.supadow_minigames.value == 0:
                 continue
-
+            if "Supadow Minigames" in data.location_group and self.options.supadow_minigames.value != 0:
+                #Exclude Hard supadow checks if on Easy
+                if "Supadow Hard" in data.location_group and self.options.supadow_minigames.value < 2:
+                    continue
+                # Exclude Real Tough supadow checks if on Hard and bellow
+                if "Supadow Real Tough" in data.location_group and self.options.supadow_minigames.value < 3:
+                    continue
             if "Mission Specific Item Locations" in data.location_group and self.options.randomize_mission_items:
                 continue
 
@@ -479,7 +488,7 @@ class GrinchWorld(World):
                 self_itempool.append((self.create_item("Progressive Vacuum Tube")))
 
         for supadow_door in SUPADOW_TABLE:
-            if self.options.supadow_minigames:
+            if self.options.supadow_minigames > 0:
                 self_itempool.append(self.create_item(supadow_door))
 
         # Get number of current unfilled locations


### PR DESCRIPTION
- Implemented checks by difficulty (And points count checks for Spin N Win). Corresponding checks need to be done at the correct difficulty to count
- Supadow Minigames YAML options: None, Easy, Hard, Real Tough (Include all checks at X difficulty and bellow)
- Fixed Bizhawk connection being unstable on disconnect/client crash
- Started grouping RAM addresses into RamHandler.py