### PR TITLE
Add Max advanced access for OCD BP near Right Side of Power Plant Wall

### DIFF
--- a/worlds/grinch/Rules.py
+++ b/worlds/grinch/Rules.py
@@ -1188,6 +1188,11 @@ ALL_LOCATIONS_INFO: dict[str, GrinchLocationInfo] = {
                 grinch_items.moves.PANCAKE,
             ],
         ],
+        advanced_location_access=[
+            [
+                grinch_items.moves.MAX,
+            ],
+        ],
     ),
     "WD - OCD BP near Who-Bris' Shack": GrinchLocationInfo(
         location_access=[


### PR DESCRIPTION
Add advanced logic of using just Max to get WD - OCD BP near Right Side of Power Plant Wall